### PR TITLE
 refact: Email 전송 로직 리팩토링

### DIFF
--- a/src/main/java/com/zerobase/task/invite/api/member/controller/MemberController.java
+++ b/src/main/java/com/zerobase/task/invite/api/member/controller/MemberController.java
@@ -46,9 +46,9 @@ public class MemberController {
         return ResponseEntity.ok(savedMember);
     }
 
-    @GetMapping(value = "/mail/send")
-    public ResponseEntity<String> sendMail() {
-        mailService.sendMail("woosuk1893@naver.com", "테스트 메일", "<h1>안녕하세요 메일 테스트 입니다.</h1>");
-        return ResponseEntity.ok("메일이 성공적으로 발송 되었습니다.");
-    }
+//    @GetMapping(value = "/mail/send")
+//    public ResponseEntity<String> sendMail() {
+//        mailService.sendMail("woosuk1893@naver.com", "테스트 메일", "<h1>안녕하세요 메일 테스트 입니다.</h1>");
+//        return ResponseEntity.ok("메일이 성공적으로 발송 되었습니다.");
+//    }
 }

--- a/src/main/java/com/zerobase/task/invite/domain/invite/service/InviteService.java
+++ b/src/main/java/com/zerobase/task/invite/domain/invite/service/InviteService.java
@@ -37,38 +37,38 @@ public class InviteService {
      *
      * @param inviteRequest
      */
-    @Transactional
-    public Invite createInvite(final InviteRequest inviteRequest) {
-        verifyInviteRequest(inviteRequest);
-
-        // 초대 생성시 초기에는 임시 회원으로 생성
-        Member tempMember = new Member(
-            inviteRequest.getName(),
-            inviteRequest.getAge(),
-            inviteRequest.getPhoneNumber(),
-            inviteRequest.getEmail()
-        );
-
-        Member savedMember = memberRepository.save(tempMember);
-
-        Long inviterId = inviteRequest.getInviterMemberId();
-        Long participantId = savedMember.getMemberId();
-        String subject = "초대장 입니다.";
-        String code = RandomCode.getRandomCode();
-
-        // 초대 메일 발송
-        mailService.sendMail(
-            inviteRequest.getEmail(),
-            subject,
-            getInviteMailBody(
-                inviteRequest.getEmail(),
-                inviteRequest.getName(),
-                code
-            )
-        );
-
-        return inviteRepository.save(new Invite(inviterId, participantId, code));
-    }
+//    @Transactional
+//    public Invite createInvite(final InviteRequest inviteRequest) {
+//        verifyInviteRequest(inviteRequest);
+//
+//        // 초대 생성시 초기에는 임시 회원으로 생성
+//        Member tempMember = new Member(
+//            inviteRequest.getName(),
+//            inviteRequest.getAge(),
+//            inviteRequest.getPhoneNumber(),
+//            inviteRequest.getEmail()
+//        );
+//
+//        Member savedMember = memberRepository.save(tempMember);
+//
+//        Long inviterId = inviteRequest.getInviterMemberId();
+//        Long participantId = savedMember.getMemberId();
+//        String subject = "초대장 입니다.";
+//        String code = RandomCode.getRandomCode();
+//
+//        // 초대 메일 발송
+//        mailService.sendMail(
+//            inviteRequest.getEmail(),
+//            subject,
+//            getInviteMailBody(
+//                inviteRequest.getEmail(),
+//                inviteRequest.getName(),
+//                code
+//            )
+//        );
+//
+//        return inviteRepository.save(new Invite(inviterId, participantId, code));
+//    }
 
     public String getInviteMailBody(String email, String name, String code) {
         StringBuilder builder = new StringBuilder();

--- a/src/main/java/com/zerobase/task/invite/infra/mail/InviteMessagePreparator.java
+++ b/src/main/java/com/zerobase/task/invite/infra/mail/InviteMessagePreparator.java
@@ -1,0 +1,20 @@
+package com.zerobase.task.invite.infra.mail;
+
+import jakarta.mail.internet.MimeMessage;
+import lombok.RequiredArgsConstructor;
+import org.springframework.mail.javamail.MimeMessageHelper;
+import org.springframework.mail.javamail.MimeMessagePreparator;
+
+@RequiredArgsConstructor
+public class InviteMessagePreparator implements MimeMessagePreparator {
+
+    private final MailMessageInfo messageInfo;
+
+    @Override
+    public void prepare(MimeMessage mimeMessage) throws Exception {
+        MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true, "UTF-8");
+        mimeMessageHelper.setTo(messageInfo.getTo());
+        mimeMessageHelper.setSubject(messageInfo.getSubject());
+        mimeMessageHelper.setText(messageInfo.getContent(), true);
+    }
+}

--- a/src/main/java/com/zerobase/task/invite/infra/mail/MailMessageInfo.java
+++ b/src/main/java/com/zerobase/task/invite/infra/mail/MailMessageInfo.java
@@ -1,0 +1,10 @@
+package com.zerobase.task.invite.infra.mail;
+
+import lombok.Data;
+
+@Data
+public class MailMessageInfo {
+    private final String to;
+    private final String subject;
+    private final String content;
+}

--- a/src/main/java/com/zerobase/task/invite/infra/mail/MailService.java
+++ b/src/main/java/com/zerobase/task/invite/infra/mail/MailService.java
@@ -28,18 +28,9 @@ public class MailService {
         mailSender.send(smm);
     }
 
-    public void sendMail(String to, String subject, String content) {
+    public void sendMail(MailMessageInfo mailMessageInfo) {
 
-        MimeMessagePreparator mimeMessagePreparator = new MimeMessagePreparator() {
-            @Override
-            public void prepare(MimeMessage mimeMessage) throws Exception {
-                MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage, true,
-                    "UTF-8");
-                mimeMessageHelper.setTo(to);
-                mimeMessageHelper.setSubject(subject);
-                mimeMessageHelper.setText(content, true);
-            }
-        };
+        final MimeMessagePreparator mimeMessagePreparator = new InviteMessagePreparator(mailMessageInfo);
 
         try {
             javaMailSender.send(mimeMessagePreparator);


### PR DESCRIPTION
작성해놓으신 MailSend 쪽 파라미터가 MimeMessagePreparator 이고 해당 인터페이스가 펑셔널 인터페이스로 되어있내요. 
( 상위 인터페이스가 없음 ) 그러다 보니 기존에 이야기 했던것 처럼 팩토리패턴을 통해 Mime 타입 이외에 여러 타입들을 만들어 놓고 사용하기엔
어려운 메소드 구조인것 같아요. ( Mime 타입 말고는 지원하지도 않는거 같네요! ) 일단은 요정도로 리팩토링 하고 넘어가도 괜찮을것 같아요.